### PR TITLE
Fix dependency issue

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class elasticsearch(
 ) inherits elasticsearch::params {
 
   include java
+  require homebrew
 
   class { 'elasticsearch::package':
     ensure  => $ensure,


### PR DESCRIPTION
I get the following error on a pristine Boxen installation:

> ``` Error:
> /Stage[main]/Elasticsearch::Package/Exec[/opt/boxen/homebrew/bin/plugin --install elasticsearch/elasticsearch-lang-javascript/2.1.0]: Could not evaluate: Could not find command '/opt/boxen/homebrew/bin/plugin'
> ```

This change addresses that.

```
Using rake (10.3.1) 
Using CFPropertyList (2.2.7) 
Using addressable (2.3.6) 
Using ansi (1.4.3) 
Using json_pure (1.8.1) 
Using hiera (1.3.2) 
Using highline (1.6.21) 
Using json (1.8.1) 
Using thor (0.19.1) 
Using librarian (0.1.2) 
Using librarian-puppet (1.0.1) 
Using multipart-post (2.0.0) 
Using faraday (0.9.0) 
Using sawyer (0.5.4) 
Using octokit (2.7.2) 
Using facter (2.0.1) 
Using rgen (0.6.6) 
Using puppet (3.5.1) 
Using boxen (2.6.0) 
Using puppet-lint (0.3.2) 
Using metaclass (0.0.4) 
Using mocha (1.0.0) 
Using rspec-core (2.14.8) 
Using diff-lcs (1.2.5) 
Using rspec-expectations (2.14.5) 
Using rspec-mocks (2.14.6) 
Using rspec (2.14.1) 
Using rspec-puppet (1.0.1) 
Using puppetlabs_spec_helper (0.4.1) 
Using cardboard (2.1.0) 
Using bundler (1.3.5) 
Your bundle is complete!
It was installed into ./.bundle
--> Checking syntax:
./manifests/config.pp: Syntax OK
./manifests/init.pp: Syntax OK
./manifests/package.pp: Syntax OK
./manifests/params.pp: Syntax OK
./manifests/service.pp: Syntax OK
./spec/classes/elasticsearch_config_spec.rb: Syntax OK
./spec/classes/elasticsearch_package_spec.rb: Syntax OK
./spec/classes/elasticsearch_service_spec.rb: Syntax OK
./spec/classes/elasticsearch_spec.rb: Syntax OK
./spec/spec_helper.rb: Syntax OK
./templates/dev.elasticsearch.plist.erb: Syntax OK
./templates/elasticsearch.yml.erb: Syntax OK
./templates/env.sh.erb: Syntax OK
--> Running specs:

elasticsearch::config
  should contain File[/test/boxen/env.d/elasticsearch.sh] with ensure => :absent

elasticsearch::package
  should contain Package[boxen/brews/elasticsearch] with ensure => "1.1.1-boxen1"

elasticsearch::service
  should contain Service[dev.elasticsearch] with ensure => :running, enable => true and alias => "elasticsearch"

elasticsearch
  should include Class[java]

Finished in 2.99 seconds
4 examples, 0 failures
--> Checking lint:
```
