### PR TITLE
Log all queries in the 'slow' log

### DIFF
--- a/templates/elasticsearch.yml.erb
+++ b/templates/elasticsearch.yml.erb
@@ -8,6 +8,11 @@ node:
 index:
   number_of_shards: 1
   number_of_replicas: 0
+  search:
+    slowlog:
+      threshold:
+        query:
+          trace: 0ms
 
 path:
   conf: <%= @configdir %>/


### PR DESCRIPTION
It's good to have query logging in development.

The boxen config already sets `index.search.slowlog` to `TRACE` level.

/cc @envato/search 
