### PR TITLE
Update to upstream 1.4.2 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # elasticsearch Puppet Module for Boxen
 
-[![Build Status](https://travis-ci.org/boxen/puppet-elasticsearch.png?branch=master)](https://travis-ci.org/boxen/puppet-elasticsearch)
+[![Build Status](https://travis-ci.org/boxen/puppet-elasticsearch.svg?branch=master)](https://travis-ci.org/boxen/puppet-elasticsearch)
 
 Install [elasticsearch](http://www.elasticsearch.org), a distributed,
 RESTful search engine. The `BOXEN_ELASTICSEARCH_PORT` and

--- a/files/brews/elasticsearch.rb
+++ b/files/brews/elasticsearch.rb
@@ -1,40 +1,60 @@
-require 'formula'
-
 class Elasticsearch < Formula
-  homepage 'http://www.elasticsearch.org'
-  url 'https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.1.1.tar.gz'
-  sha1 '8495b928984945728635f805f6e2e7183902a3ea'
-  version '1.1.1-boxen1'
+  homepage "http://www.elasticsearch.org"
+  url "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.2.tar.gz"
+  sha1 "ae381615ec7f657e2a08f1d91758714f13d11693"
+
+  version '1.4.2-boxen1'
+
+  depends_on :java => "1.7+"
+
+  head do
+    url "https://github.com/elasticsearch/elasticsearch.git"
+    depends_on "maven" => :build
+  end
 
   def cluster_name
-    "elasticsearch_#{ENV['USER']}"
+    "elasticsearch_#{ENV["USER"]}"
   end
 
   def install
-    # Remove Windows files
-    rm_f Dir["bin/*.bat"]
-    # Move JARs from lib to libexec according to homebrew conventions
-    libexec.install Dir['lib/*.jar']
-    (libexec+'sigar').install Dir['lib/sigar/*.jar']
-
-    # Install everything directly into folder
-    prefix.install Dir['*']
-
-    inreplace "#{bin}/elasticsearch.in.sh" do |s|
-      # Replace CLASSPATH paths to use libexec instead of lib
-      s.gsub! /ES_HOME\/lib\//, "ES_HOME/libexec/"
+    if build.head?
+      # Build the package from source
+      system "mvn", "clean", "package", "-DskipTests"
+      # Extract the package to the current directory
+      system "tar", "--strip", "1", "-xzf", "target/releases/elasticsearch-*.tar.gz"
     end
 
-    inreplace "#{bin}/elasticsearch" do |s|
-      # Set ES_HOME to prefix value
-      s.gsub! /^ES_HOME=.*$/, "ES_HOME=#{prefix}"
+    # Remove Windows files
+    rm_f Dir["bin/*.bat"]
+    rm_f Dir["bin/*.exe"]
+
+    # Move libraries to `libexec` directory
+    libexec.install Dir["lib/*.jar"]
+    (libexec/"sigar").install Dir["lib/sigar/*.{jar,dylib}"]
+
+    # Install everything else into package directory
+    prefix.install Dir["*"]
+
+    # Remove unnecessary files
+    rm_f Dir["#{lib}/sigar/*"]
+    if build.head?
+      rm_rf "#{prefix}/pom.xml"
+      rm_rf "#{prefix}/src/"
+      rm_rf "#{prefix}/target/"
+    end
+
+    inreplace "#{bin}/elasticsearch.in.sh" do |s|
+      # Configure ES_HOME
+      s.sub!(%r{#\!/bin/sh\n}, "#!/bin/sh\n\nES_HOME=#{prefix}")
+      # Configure ES_CLASSPATH paths to use libexec instead of lib
+      s.gsub!(%r{ES_HOME/lib/}, "ES_HOME/libexec/")
     end
 
     inreplace "#{bin}/plugin" do |s|
-      # Set ES_HOME to prefix value
-      s.gsub! /^ES_HOME=.*$/, "ES_HOME=#{prefix}"
-      # Replace CLASSPATH paths to use libexec instead of lib
-      s.gsub! /-cp \".*\"/, '-cp "$ES_HOME/libexec/*"'
+      # Add the proper ES_CLASSPATH configuration
+      s.sub!(/SCRIPT="\$0"/, %(SCRIPT="$0"\nES_CLASSPATH=#{libexec}))
+      # Replace paths to use libexec instead of lib
+      s.gsub!(%r{\$ES_HOME/lib/}, "$ES_CLASSPATH/")
     end
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,8 @@ class elasticsearch(
 
     version => $version,
     package => $package,
+
+    notify  => Service['elasticsearch']
   }
 
   ~>

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -21,7 +21,7 @@ class elasticsearch::package(
 
   # TODO turn this into a proper puppet definition if we have more plugins
   $es_plugin_cmd = "${boxen::config::homebrewdir}/bin/plugin"
-  $javascript_plugin = 'elasticsearch/elasticsearch-lang-javascript/2.1.0'
+  $javascript_plugin = 'elasticsearch/elasticsearch-lang-javascript/2.4.1'
   exec { "${es_plugin_cmd} --install ${javascript_plugin}":
     unless  => "${es_plugin_cmd} --list | grep javascript",
     require => Package[$package],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class elasticsearch::params {
 
       $ensure         = 'present'
 
-      $version        = '1.1.1-boxen1'
+      $version        = '1.4.2-boxen1'
       $package        = 'boxen/brews/elasticsearch'
 
       $cluster        = "elasticsearch_boxen_${::boxen_user}"

--- a/spec/classes/elasticsearch_package_spec.rb
+++ b/spec/classes/elasticsearch_package_spec.rb
@@ -6,6 +6,6 @@ describe "elasticsearch::package" do
   it do
     should contain_homebrew__formula("elasticsearch")
 
-    should contain_package("boxen/brews/elasticsearch").with_ensure("1.1.1-boxen1")
+    should contain_package("boxen/brews/elasticsearch").with_ensure("1.4.2-boxen1")
   end
 end

--- a/spec/classes/elasticsearch_spec.rb
+++ b/spec/classes/elasticsearch_spec.rb
@@ -4,10 +4,10 @@ describe 'elasticsearch' do
   let(:facts) { default_test_facts }
 
   it do
-    should include_class("elasticsearch::config")
-    should include_class("elasticsearch::package")
-    should include_class("elasticsearch::service")
+    should contain_class("elasticsearch::config")
+    should contain_class("elasticsearch::package")
+    should contain_class("elasticsearch::service")
 
-    should include_class("java")
+    should contain_class("java")
   end
 end

--- a/templates/elasticsearch.yml.erb
+++ b/templates/elasticsearch.yml.erb
@@ -46,3 +46,6 @@ discovery:
       unicast:
         hosts:
           - <%= @host %>:<%= @transport_port %>
+
+script:
+  disable_dynamic: true

--- a/templates/elasticsearch.yml.erb
+++ b/templates/elasticsearch.yml.erb
@@ -48,4 +48,4 @@ discovery:
           - <%= @host %>:<%= @transport_port %>
 
 script:
-  disable_dynamic: true
+  disable_dynamic: false


### PR DESCRIPTION
This is a prerequisite for upgrading ES in boxen

* Pulls in `upstream/upgrade-1.4.2`
* Updates the javascript plugin to a compatible version
* Doesn't disable scripting


/cc @envato/search 